### PR TITLE
Refactor: Make Spotify generate cache process better

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,18 +6,13 @@ from typing import Any
 
 import jdk
 import requests
-import urllib.parse
 import yaml
+import time
+import base64
 from git import Repo, NoSuchPathError
 from inquirer import text, confirm
+from urllib.parse import parse_qsl, urlparse, quote
 from requests.exceptions import HTTPError
-import base64
-
-
-def short_url(url: str):
-    encoded_url = urllib.parse.quote(url, safe="")
-    response = requests.get(f"https://ulvis.net/API/write/get?url={encoded_url}")
-    return response.json()["data"]["url"]
 
 
 def info(obj: Any):
@@ -33,10 +28,8 @@ def success(obj: Any):
 
 
 def valid_token(_, token: str) -> bool:
-    response = requests.get(
-        "https://discord.com/api/v10/users/@me",
-        headers={"Authorization": "Bot " + token},
-    )
+    response = requests.get("https://discord.com/api/v10/users/@me",
+                            headers={"Authorization": "Bot " + token})
 
     return response.status_code == 200
 
@@ -71,9 +64,7 @@ def clone_lava() -> Repo:
         info("Cloning Lava...")
 
         repo = Repo.clone_from(
-            getenv("git_repo", "https://github.com/Nat1anWasTaken/Lava.git"),
-            "./lava",
-            branch="master",
+            getenv("git_repo", "https://github.com/Nat1anWasTaken/Lava.git"), "./lava", branch="master"
         )
 
     success("Lava cloned successfully!")
@@ -129,36 +120,32 @@ def fill_secrets():
                 f"https://accounts.spotify.com/authorize?client_id={spotify_client_id}&response_type=code&redirect_uri={spotify_redirect_uri}"
             )
 
-            url = text(
-                message=f"""
+            url = input(f"""
 Go to the following URL: {shorted_url}
-Enter the URL you were redirected to"""
-            )
+Enter the URL you were redirected to: """)
 
-            parts = url.split("code=")
-
-            code = parts[1]
+            code = parse_auth_response_url(url)
 
             headers = {
-                "Authorization": "Basic "
-                + base64.b64encode(
-                    (spotify_client_id + ":" + spotify_client_secret).encode("ascii")
-                ).decode("ascii"),
-                "content-type": "application/x-www-form-urlencoded",
+                'content-type': 'application/x-www-form-urlencoded',
+                'Authorization': 'Basic ' + base64.b64encode((spotify_client_id + ':' + spotify_client_secret).encode(
+                'ascii')).decode('ascii')
             }
 
             data = {
-                "grant_type": "authorization_code",
-                "code": code,
-                "redirect_uri": spotify_redirect_uri,
+                'client_id': spotify_client_id,
+                'grant_type': 'authorization_code',
+                'code': code,
+                'redirect_uri': spotify_redirect_uri,
             }
 
             r = requests.post(
-                url="https://accounts.spotify.com/api/token", headers=headers, data=data
-            )
+                url="https://accounts.spotify.com/api/token", headers=headers, data=data)
+            
+            token_info = add_custom_values_to_token_info(r.json())
 
             if r.status_code == 200:
-                cache_file.write(str(r.json()))
+                cache_file.write(str(json.dumps(token_info)))
             else:
                 raise HTTPError("Invalid authorization code.")
 
@@ -182,9 +169,7 @@ Enter the URL you were redirected to"""
 
 
 def set_ports():
-    if path.isfile("lava/configs/lavalink.json") and path.isfile(
-        "lavalink/application.yml"
-    ):
+    if path.isfile("lava/configs/lavalink.json") and path.isfile("lavalink/application.yml"):
         warning("lavalink.json and application.yml file already exists, skipping...")
 
         return
@@ -192,7 +177,7 @@ def set_ports():
     port = text(
         "Please enter the port for lavalink",
         default="2333",
-        validate=lambda _, x: x.isdigit(),
+        validate=lambda _, x: x.isdigit()
     )
 
     with open("configs/lavalink.json", "r+", encoding="utf-8") as f:
@@ -241,8 +226,8 @@ def get_java():
         except StopIteration:
             pass
 
-    for directory in listdir("./java"):
-        if directory.startswith("jdk"):
+    for directory in listdir('./java'):
+        if directory.startswith('jdk'):
             rename(f"./java/{directory}", f"./java/jdk")
             break
 
@@ -255,22 +240,35 @@ def get_lavalink():
     if path.isfile("./lavalink/Lavalink.jar"):
         return
 
-    if not path.isdir("./lavalink"):
-        mkdir("./lavalink")
+    if not path.isdir('./lavalink'):
+        mkdir('./lavalink')
 
     data = requests.get(
-        "https://api.github.com/repos/freyacodes/Lavalink/releases/latest"
-    ).json()
+        "https://api.github.com/repos/freyacodes/Lavalink/releases/latest").json()
 
     jar = requests.get(data["assets"][0]["browser_download_url"])
 
-    with open("./lavalink/Lavalink.jar", "wb") as f:
+    with open("./lavalink/Lavalink.jar", 'wb') as f:
         f.write(jar.content)
 
     shutil.copyfile("configs/application.yml", "lavalink/application.yml")
 
     success("Lavalink installed successfully!")
 
+def add_custom_values_to_token_info(token_info):
+    token_info["expires_at"] = int(time.time()) + token_info["expires_in"]
+    token_info["scope"] = None
+    return token_info
+
+def parse_auth_response_url(url):
+    query_s = urlparse(url).query
+    form = dict(parse_qsl(query_s))
+    return form.get('code')
+
+def short_url(url: str):
+    encoded_url = quote(url, safe="")
+    response = requests.get(f"https://ulvis.net/API/write/get?url={encoded_url}")
+    return response.json()["data"]["url"]
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,10 @@ def success(obj: Any):
 
 
 def valid_token(_, token: str) -> bool:
-    response = requests.get("https://discord.com/api/v10/users/@me",
-                            headers={"Authorization": "Bot " + token})
+    response = requests.get(
+        "https://discord.com/api/v10/users/@me",
+        headers={"Authorization": "Bot " + token},
+    )
 
     return response.status_code == 200
 
@@ -64,7 +66,9 @@ def clone_lava() -> Repo:
         info("Cloning Lava...")
 
         repo = Repo.clone_from(
-            getenv("git_repo", "https://github.com/Nat1anWasTaken/Lava.git"), "./lava", branch="master"
+            getenv("git_repo", "https://github.com/Nat1anWasTaken/Lava.git"),
+            "./lava",
+            branch="master",
         )
 
     success("Lava cloned successfully!")
@@ -120,28 +124,33 @@ def fill_secrets():
                 f"https://accounts.spotify.com/authorize?client_id={spotify_client_id}&response_type=code&redirect_uri={spotify_redirect_uri}"
             )
 
-            url = input(f"""
+            url = input(
+                f"""
 Go to the following URL: {shorted_url}
-Enter the URL you were redirected to: """)
+Enter the URL you were redirected to: """
+            )
 
             code = parse_auth_response_url(url)
 
             headers = {
-                'content-type': 'application/x-www-form-urlencoded',
-                'Authorization': 'Basic ' + base64.b64encode((spotify_client_id + ':' + spotify_client_secret).encode(
-                'ascii')).decode('ascii')
+                "content-type": "application/x-www-form-urlencoded",
+                "Authorization": "Basic "
+                + base64.b64encode(
+                    (spotify_client_id + ":" + spotify_client_secret).encode("ascii")
+                ).decode("ascii"),
             }
 
             data = {
-                'client_id': spotify_client_id,
-                'grant_type': 'authorization_code',
-                'code': code,
-                'redirect_uri': spotify_redirect_uri,
+                "client_id": spotify_client_id,
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": spotify_redirect_uri,
             }
 
             r = requests.post(
-                url="https://accounts.spotify.com/api/token", headers=headers, data=data)
-            
+                url="https://accounts.spotify.com/api/token", headers=headers, data=data
+            )
+
             token_info = add_custom_values_to_token_info(r.json())
 
             if r.status_code == 200:
@@ -169,7 +178,9 @@ Enter the URL you were redirected to: """)
 
 
 def set_ports():
-    if path.isfile("lava/configs/lavalink.json") and path.isfile("lavalink/application.yml"):
+    if path.isfile("lava/configs/lavalink.json") and path.isfile(
+        "lavalink/application.yml"
+    ):
         warning("lavalink.json and application.yml file already exists, skipping...")
 
         return
@@ -177,7 +188,7 @@ def set_ports():
     port = text(
         "Please enter the port for lavalink",
         default="2333",
-        validate=lambda _, x: x.isdigit()
+        validate=lambda _, x: x.isdigit(),
     )
 
     with open("configs/lavalink.json", "r+", encoding="utf-8") as f:
@@ -226,8 +237,8 @@ def get_java():
         except StopIteration:
             pass
 
-    for directory in listdir('./java'):
-        if directory.startswith('jdk'):
+    for directory in listdir("./java"):
+        if directory.startswith("jdk"):
             rename(f"./java/{directory}", f"./java/jdk")
             break
 
@@ -240,35 +251,40 @@ def get_lavalink():
     if path.isfile("./lavalink/Lavalink.jar"):
         return
 
-    if not path.isdir('./lavalink'):
-        mkdir('./lavalink')
+    if not path.isdir("./lavalink"):
+        mkdir("./lavalink")
 
     data = requests.get(
-        "https://api.github.com/repos/freyacodes/Lavalink/releases/latest").json()
+        "https://api.github.com/repos/freyacodes/Lavalink/releases/latest"
+    ).json()
 
     jar = requests.get(data["assets"][0]["browser_download_url"])
 
-    with open("./lavalink/Lavalink.jar", 'wb') as f:
+    with open("./lavalink/Lavalink.jar", "wb") as f:
         f.write(jar.content)
 
     shutil.copyfile("configs/application.yml", "lavalink/application.yml")
 
     success("Lavalink installed successfully!")
 
+
 def add_custom_values_to_token_info(token_info):
     token_info["expires_at"] = int(time.time()) + token_info["expires_in"]
     token_info["scope"] = None
     return token_info
 
+
 def parse_auth_response_url(url):
     query_s = urlparse(url).query
     form = dict(parse_qsl(query_s))
-    return form.get('code')
+    return form.get("code")
+
 
 def short_url(url: str):
     encoded_url = quote(url, safe="")
     response = requests.get(f"https://ulvis.net/API/write/get?url={encoded_url}")
     return response.json()["data"]["url"]
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Refactor the Spotify login process to use the updated code and URL handling. Update the code to prompt the user to visit the provided URL and enter the redirected URL. Parse the authorization code from the URL and make a POST request to the Spotify API to exchange the code for an access token. Cache the token information if the request is successful. Handle errors when the authorization code is invalid.